### PR TITLE
customisation of health upon death

### DIFF
--- a/data/vip/functions/defaults.mcfunction
+++ b/data/vip/functions/defaults.mcfunction
@@ -27,6 +27,9 @@ scoreboard players set speed_uhc global 1
 # death time
 scoreboard players set death_time global 25
 
+# +health upon death
+scoreboard players set kill_health global 1
+
 # world
 worldborder set 10
 gamerule doImmediateRespawn true

--- a/data/vip/functions/main.mcfunction
+++ b/data/vip/functions/main.mcfunction
@@ -21,7 +21,8 @@ execute if score period internal matches 1 if score team_count global matches 3 
 execute if score period internal matches 1 if score team_count global matches 4 run function vip:teams/4
 
 # kills
-execute as @a if score @s kill matches 1.. run function vip:kills
+execute as @a if score @s kill matches 1.. if score kill_health global matches 1.. run function vip:kills
+execute as @a if score @s kill matches 1.. run scoreboard players reset @s kill
 
 # timer
 execute if score period internal matches 0..2 run function vip:time

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "description": "VIP for 1.18\n\u00A762022.0214 \u00A7r• \u00A7bplexion.dev",
-        "pack_format": 8
+        "description": "VIP for 1.19\n\u00A762022.0612 \u00A7r• \u00A7bplexion.dev",
+        "pack_format": 10
     }
 }


### PR DESCRIPTION
- closes #1 

adds `kill_health` as a `global` option, defaults to enabled (1). toggles whether the VIP gains health upon a team member getting a kill.

was originally intending to also cover #2 but realised that is out of scope.